### PR TITLE
Fixed getting attributes of cursor.

### DIFF
--- a/tormysql/cursor.py
+++ b/tormysql/cursor.py
@@ -55,7 +55,7 @@ class Cursor(object):
         return self._cursor.__iter__()
 
     def __getattr__(self, name):
-        return self._cursor.__getattr__(name)
+        return getattr(self._cursor, name)
 
 setattr(OriginCursor, "__tormysql_class__", Cursor)
 


### PR DESCRIPTION
Getting attributes of cursor, like: cursor.rowcount, cursor.lastrowid etc. did not work because `__getattr__` is a private method.